### PR TITLE
Fix Warrior profession causing collapsed mummies to not take damage from bombs?

### DIFF
--- a/C# Code/Managers/CombatManager.cs
+++ b/C# Code/Managers/CombatManager.cs
@@ -60,8 +60,12 @@ namespace VanillaPlusProfessions.Managers
         {
             try
             {
-                if (CoreUtility.CurrentPlayerHasProfession("Warrior", useThisInstead: who))
                 {
+                    if (isBomb)
+                    {
+                        // Base takeDamange should be sufficient for bom
+                        return;
+                    }
                     int actualDamage = Math.Max(1, damage - __instance.resilience.Value);
                     if (Game1.random.NextDouble() < __instance.missChance.Value - __instance.missChance.Value * addedPrecision)
                     {
@@ -77,22 +81,13 @@ namespace VanillaPlusProfessions.Managers
                         __instance.IsWalkingTowardPlayer = true;
                         if (__instance.Health <= 0)
                         {
-                            if (!isBomb)
+                            Utility.makeTemporarySpriteJuicier(new TemporaryAnimatedSprite(44, __instance.Position, Color.BlueViolet, 10)
                             {
-                                Utility.makeTemporarySpriteJuicier(new TemporaryAnimatedSprite(44, __instance.Position, Color.BlueViolet, 10)
-                                {
-                                    holdLastFrame = true,
-                                    alphaFade = 0.01f,
-                                    interval = 70f
-                                }, __instance.currentLocation);
-                                __instance.currentLocation.playSound("ghost");
-                            }
-                            else
-                            {
-                                __instance.reviveTimer.Value = 10000;
-                                __instance.Health = __instance.MaxHealth;
-                                __instance.deathAnimation();
-                            }
+                                holdLastFrame = true,
+                                alphaFade = 0.01f,
+                                interval = 70f
+                            }, __instance.currentLocation);
+                            __instance.currentLocation.playSound("ghost");
                         }
                     }
                     __result = actualDamage;

--- a/C# Code/Managers/CombatManager.cs
+++ b/C# Code/Managers/CombatManager.cs
@@ -63,7 +63,7 @@ namespace VanillaPlusProfessions.Managers
                 {
                     if (isBomb)
                     {
-                        // Base takeDamange should be sufficient for bom
+                        // Base takeDamange should be sufficient for bombs
                         return;
                     }
                     int actualDamage = Math.Max(1, damage - __instance.resilience.Value);


### PR DESCRIPTION
I had a bug where I have the warrior profession and tried to bomb a collapsed mummy, but the mummy wouldn't take damage.  I think the only way to get into this situation with the profession is to use bombs or the napalm ring, so I'm not sure how often this would actually happen to a player.  I only noticed because I was testing something else related to bombs

I think the base game's takeDamage should be enough to handle everything related to bombs for mummies?

I tested this on my save, and it does seem to work, but I'm not sure about multiplayer

Also, I'm inclined to think that the code here causes mummies to take double damage if the player is using a weapon that has the crusader enchantment, but maybe that's intended 