### PR TITLE
BugFix for Talent on Enemy Death

### DIFF
--- a/C# Code/CorePatcher.cs
+++ b/C# Code/CorePatcher.cs
@@ -89,15 +89,20 @@ namespace VanillaPlusProfessions
             }
         }
 
-        public static void getPlatformAchievement_Postfix()
+        public static void getPlatformAchievement_Postfix(string which)
         {
             //There's a "retroactive achievements" thing because of some platforms not allowing achievements unless player actually does it.
             //So the game tries to restore lost achievements when the save loads and the day starts
             if (!ModEntry.ModConfig.Value.ProfessionsOnly && Game1.hasStartedDay)
             {
+                //This is a workaround for the "Protector Of The Valley" achievement, since the game tries to retroactively give it to the player every monster kill.
+                if (ModEntry.MonsterSlayerCompleted.Value && which == "Achievement_KeeperOfTheMysticRings") return;
+                if(which == "Achievement_KeeperOfTheMysticRings") ModEntry.MonsterSlayerCompleted.Value = true;
+                ModEntry.ModMonitor.Log($"Adding achievement {which} talent point to player", LogLevel.Debug);
                 TalentCore.AddTalentPoint();
             }
         }
+
         public static IEnumerable<CodeInstruction> DoFunction_Transpiler(IEnumerable<CodeInstruction> insns)
         {
             try

--- a/C# Code/ModEntry.cs
+++ b/C# Code/ModEntry.cs
@@ -56,6 +56,7 @@ namespace VanillaPlusProfessions
         internal static PerScreen<int> GeodeStackSize = new(() => 0);
         internal static PerScreen<bool> IsUninstalling = new(() => false);
         internal static PerScreen<bool> IsRecalculatingPoints = new(() => false);
+        internal static PerScreen<bool> MonsterSlayerCompleted = new(() => false);
 
         internal static PerScreen<Config> ModConfig = new(createNewState: () => new Config());
 

--- a/C# Code/Talents/TalentCore.cs
+++ b/C# Code/Talents/TalentCore.cs
@@ -509,6 +509,7 @@ namespace VanillaPlusProfessions.Talents
                     return true;
                 });
             }
+            ModEntry.MonsterSlayerCompleted.Value = Game1.player.hasCompletedAllMonsterSlayerQuests.Value;
         }
         internal static void OnMailFlagGiven(string flag)
         {


### PR DESCRIPTION
If a player has completed the monster eradication goals, the game will try retro-actively give the achievement in case it was missed. This check fixes this issue by verifying if the player already had the achievement.

Personally, the harmony patch will potentially cause more bugs than benefit (it would be rare someone doesn't get the achievement straight away) but at least this fixes the issue :)