### PR TITLE
Update manifest.json to fix WearMoreRings Api

### DIFF
--- a/C# Code/manifest.json
+++ b/C# Code/manifest.json
@@ -2,7 +2,7 @@
   "Name": "Vanilla Plus Professions",
   "Author": "KediDili",
   "Description": "Adds further branches to vanilla professions.",
-  "Version": "1.0.7",
+  "Version": "1.0.8",
   "UniqueID": "KediDili.VanillaPlusProfessions",
   "EntryDLL": "VanillaPlusProfessions.dll",
   "MinimumApiVersion": "4.0.0",
@@ -12,6 +12,10 @@
       "UniqueID": "Pathoschild.ContentPatcher",
       "IsRequired": false
     },
+   {
+     "UniqueID": "bcmpinc.WearMoreRings",
+     "IsRequired": false
+   },
     {
       "UniqueID": "spacechase0.SpaceCore",
       "IsRequired": true


### PR DESCRIPTION
Fixes the Null Error on GetAllTrinketRings when using WearMoreRings.

Issue was SMAPI was loading this before WearMoreRings on save load, which meant the rings weren't loaded yet. By adding the dependency, SMAPI loads VPP after and it works fine. Can remove most of the null checks as well.