### PR TITLE
Refactor tapper handling code, fix compatibility with Machine Terrain Framework

### DIFF
--- a/C# Code/Managers/ComboManager.cs
+++ b/C# Code/Managers/ComboManager.cs
@@ -35,7 +35,7 @@ namespace VanillaPlusProfessions.Managers
                 CoreUtility.PatchMethod(
                     PatcherName, tools[i].Name + ".canThisBeAttached",
                     original: AccessTools.Method(tools[i], "canThisBeAttached", new Type[] { typeof(StardewValley.Object), typeof(int) }),
-                    postfix: new HarmonyMethod(PatcherType, "canThisBeAttached_"+ tools[i].Name + "_Postfix")
+                    postfix: new HarmonyMethod(PatcherType, "canThisBeAttached_" + tools[i].Name + "_Postfix")
                 );
             }
             CoreUtility.PatchMethod(
@@ -67,11 +67,6 @@ namespace VanillaPlusProfessions.Managers
                 PatcherName, "Slingshot.GetAmmoCollisionSound",
                 original: AccessTools.Method(typeof(Slingshot), nameof(Slingshot.GetAmmoCollisionSound)),
                 postfix: new HarmonyMethod(PatcherType, nameof(GetAmmoCollisionSound_Postfix))
-            );
-            CoreUtility.PatchMethod(
-                PatcherName, "Object.CheckForActionOnMachine",
-                original: AccessTools.Method(typeof(StardewValley.Object), "CheckForActionOnMachine"),
-                postfix: new HarmonyMethod(PatcherType, nameof(CheckForActionOnMachine_Postfix))
             );
             CoreUtility.PatchMethod(
                 PatcherName, "Object.OutputGeodeCrusher",
@@ -222,7 +217,7 @@ namespace VanillaPlusProfessions.Managers
             catch (Exception e)
             {
                 CoreUtility.PrintError(e, PatcherName, "FishingRod.GetTackleQualifiedItemIDs", "postfixed", true);
-            }            
+            }
         }
 
         public static void DrawIconBar_Postfix(StardewValley.Object __instance, SpriteBatch spriteBatch, Vector2 location, float scaleSize)
@@ -343,42 +338,6 @@ namespace VanillaPlusProfessions.Managers
                 if (ammo.Category == -4)
                     return ammo.Price * 5;
             return 50;
-        }
-        public static void CheckForActionOnMachine_Postfix(StardewValley.Object __instance, bool justCheckingForActivity, ref bool __result)
-        {
-            try
-            {
-                if (__instance is not null && __instance.IsTapper() && __instance.Location.terrainFeatures.TryGetValue(__instance.TileLocation, out var terrainFeature) && terrainFeature is FruitTree or GiantCrop)
-                {
-                    if (!justCheckingForActivity && !__result && __instance.heldObject.Value is not null)
-                    {
-                        if (terrainFeature is FruitTree tree)
-                        {
-                            __instance.modData[ModEntry.Key_TFTapperDaysLeft] = ManagerUtility.GetProduceTimeBasedOnPrice(tree, out StardewValley.Object _);
-                        }
-                        else if (terrainFeature is GiantCrop crop)
-                        {
-                            __instance.modData[ModEntry.Key_TFTapperDaysLeft] = ManagerUtility.GetProduceTimeBasedOnPrice(crop, out StardewValley.Object _);
-                        }
-                        Game1.player.addItemByMenuIfNecessary(__instance.heldObject.Value);
-                        __instance.heldObject.Value = null;
-                        __result = true;
-                        return;
-                    }
-                    else
-                    {
-                        if (!justCheckingForActivity && terrainFeature is FruitTree tree)
-                            tree.performUseAction(__instance.TileLocation);
-                    }
-
-                    //This stays inside here, otherwise it'll break Ars Venefici.
-                    __result = false;
-                }
-            }
-            catch (Exception e)
-            {
-                CoreUtility.PrintError(e, PatcherName, "Object.CheckForActionOnMachine", "postfixed", true);
-            }
         }
         public static void GetAmmoDamage_Postfix(StardewValley.Object ammunition, ref int __result)
         {

--- a/C# Code/ModEntry.cs
+++ b/C# Code/ModEntry.cs
@@ -98,7 +98,7 @@ namespace VanillaPlusProfessions
             Helper.Events.Player.LevelChanged += OnLevelChanged;
             Helper.Events.Player.Warped += OnWarped;
             Helper.Events.GameLoop.UpdateTicked += OnUpdateTicked;
-            
+
             CorePatcher.ApplyPatches();
             TalentCore.Initialize();
             BuildingPatcher.ApplyPatches();
@@ -273,7 +273,7 @@ namespace VanillaPlusProfessions
                         bird.Update(Game1.currentGameTime);
                     }
                 }
-            }            
+            }
         }
 
         private void OnWarped(object sender, WarpedEventArgs e)
@@ -806,30 +806,6 @@ namespace VanillaPlusProfessions
                     FruitTreeData fruitTreeData = (TreeOrCrop as FruitTree)?.GetData();
                     GiantCropData giantCropData = (TreeOrCrop as GiantCrop)?.GetData();
                     var obsj = Game1.player.ActiveObject;
-
-                    obsj.modData[Key_TFTapperDaysLeft] = "0";
-
-                    StardewValley.Object dsdsd;
-                    if (fruitTreeData?.CustomFields?.TryGetValue(Key_FruitTreeOrGiantCrop, out string value) is true && value is not null)
-                    {
-                        dsdsd = ItemRegistry.Create<StardewValley.Object>(value);
-                        dsdsd.modData?.TryAdd("Kedi.VPP.CurrentPreserveType", "Other");
-                        obsj.modData[Key_TFTapperDaysLeft] = (dsdsd.Price / 20).ToString();
-                    }
-                    else if (giantCropData?.CustomFields?.TryGetValue(Key_FruitTreeOrGiantCrop, out string value2) is true && value2 is not null)
-                    {
-                        dsdsd = ItemRegistry.Create<StardewValley.Object>(value2);
-                        dsdsd.modData?.TryAdd("Kedi.VPP.CurrentPreserveType", "Other");
-                        obsj.modData[Key_TFTapperDaysLeft] = (dsdsd.Price / 20).ToString();
-                    }
-                    else
-                    {
-                        obsj.modData[Key_TFTapperDaysLeft] = ManagerUtility.GetProduceTimeBasedOnPrice(TreeOrCrop, out StardewValley.Object produce);
-                        dsdsd = produce;
-                        dsdsd.modData?.TryAdd("Kedi.VPP.CurrentPreserveType", "Kedi.VPP.FruitSyrup");
-                    }
-                    if (dsdsd is not null)
-                        obsj.lastInputItem.Value = dsdsd;
 
                     if (TreeOrCrop.modData.TryAdd(Key_TFHasTapper, "true")
                     && TreeOrCrop.modData.TryAdd(Key_TFTapperID, Game1.player.ActiveObject.QualifiedItemId))


### PR DESCRIPTION
Hi Kedi! :wave: 

VPP is currently incompatible with machines mounted on fruit trees/giant crops added by [Machine Terrain Framework](https://www.nexusmods.com/stardewvalley/mods/22975)/[Additional Tree Equipments](https://www.nexusmods.com/stardewvalley/mods/22991), regardless if Farm-Forage is chosen, because the current handling code will:

* Cause fruit tree-mounted "tappers" to collect instantly, regardless if they're still processing
* Skip out on MTF's machine handling postfixes because it sets result to true, so mushroom spores/bird houses/etc. will not produce again.

This PR refactors the handling code by:
* Eliminate the `CheckForActionOnMachine` patch entirely
* Use the built-in `MinutesUntilReady` for the tapper's processing time instead (as a bonus, it now works with UI Info Suite/Informant!), while keeping the "increment stack by 1 every X day" functionality
* Move the produce code into day update entirely