### PR TITLE
Fix LittlePlus error when getting a level up to lvl 11 in the menu

### DIFF
--- a/C# Code/DisplayHandler.cs
+++ b/C# Code/DisplayHandler.cs
@@ -385,6 +385,10 @@ namespace VanillaPlusProfessions
                     }
                     if (CoreUtility.IsOverlayValid())
                     {
+                        if (LittlePlus is null)
+                        {
+                            HandleSkillPage(page, Game1.activeClickableMenu);
+                        }
                         LittlePlus.draw(e.SpriteBatch);
                         page.drawMouse(e.SpriteBatch);
                     }
@@ -499,6 +503,10 @@ namespace VanillaPlusProfessions
 
                     if (CoreUtility.IsOverlayValid())
                     {
+                        if (LittlePlus is null)
+                        {
+                            HandleSkillPage(page2, Game1.activeClickableMenu);
+                        }
                         LittlePlus.draw(e.SpriteBatch);
                         page2.drawMouse(e.SpriteBatch);
                     }


### PR DESCRIPTION
The LittlePlus was only defined when the menu was created but the draw() was called when the Overlay became Valid, which can happen after the creation. Now if the menu detects that the overlay becomes valid and the LittlePlus is null, it handles the SkillPage/NewSkillPage.