### PR TITLE
Add compatibility between the box trough and custom feed overrides added by Extra Animal Config

### DIFF
--- a/C# Code/Compatibility/IExtraAnimalConfigApi.cs
+++ b/C# Code/Compatibility/IExtraAnimalConfigApi.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Collections.Generic;
+using StardewValley;
+using StardewValley.GameData;
+
+namespace VanillaPlusProfessions.Compatibility;
+
+public interface IExtraAnimalConfigApi
+{
+    // Get a list of every modded feed that is/can be stored;
+    // the result is a dictionary of *qualified* item IDs
+    // to an IFeedInfo object that can be used to get the capacity and modify count.
+    // The IFeedInfo object is stateless so you can save it if you want.
+    public IDictionary<string, IFeedInfo> GetModdedFeedInfo();
+    // Get the qualified id of the feed override for this building type that replaces hay, if any.
+    // Does not get any custom troughs placed alongside vanilla hay troughs in buildings
+    public string? GetFeedOverride(string? buildingId);
+}
+
+public interface IFeedInfo
+{
+    // The total capacity
+    public int capacity { get; }
+    // The current count
+    public int count { get; set; }
+}

--- a/C# Code/Constants.cs
+++ b/C# Code/Constants.cs
@@ -11,6 +11,7 @@ namespace VanillaPlusProfessions
         public const string ModId_BetterGameMenu = "leclair.bettergamemenu";
         public const string ModId_TrinketTinker = "mushymato.TrinketTinker";
         public const string ModId_ItemExtensions = "mistyspring.ItemExtensions";
+        public const string ModId_ExtraAnimalConfig = "selph.ExtraAnimalConfig";
         public const string ModId_VPPCP = "KediDili.VPPData.CP";
 
         public const string Key_HasFoundForage = "Kedi.VPP.HasFoundForageGame";
@@ -184,7 +185,7 @@ namespace VanillaPlusProfessions
         public const string Talent_Resurgence = "Resurgence";
         public const string Talent_RefreshingWaters = "RefreshingWaters";
         public const string Talent_GoodSoaking = "GoodSoaking";
-        public const string Talent_NourishingRain = "NourishingRain";        
+        public const string Talent_NourishingRain = "NourishingRain";
         public const string Talent_HarmoniousBlooming = "HarmoniousBlooming";
         public const string Talent_Abundance = "Abundance";
         public const string Talent_FairysKiss = "FairysKiss";

--- a/C# Code/ModEntry.cs
+++ b/C# Code/ModEntry.cs
@@ -44,6 +44,7 @@ namespace VanillaPlusProfessions
         internal IWearMoreRings WearMoreRingsAPI;
         internal IItemExtensions ItemExtensionsAPI;
         internal IBetterGameMenuApi BetterGameMenuAPI;
+        internal IExtraAnimalConfigApi ExtraAnimalConfigAPI;
 
         internal VanillaPlusProfessionsAPI VanillaPlusProfessionsAPI = new();
 
@@ -83,7 +84,7 @@ namespace VanillaPlusProfessions
             CoreModEntry.Value.Helper.Events.Player.LevelChanged += OnLevelChanged;
             CoreModEntry.Value.Helper.Events.Player.Warped += OnWarped;
             CoreModEntry.Value.Helper.Events.GameLoop.UpdateTicked += OnUpdateTicked;
-            
+
             CorePatcher.ApplyPatches();
             TalentCore.TalentCoreEntry.Value.Initialize(this);
             BuildingPatcher.ApplyPatches();
@@ -129,6 +130,7 @@ namespace VanillaPlusProfessions
                 me.WearMoreRingsAPI = me.Helper.ModRegistry.GetApi<IWearMoreRings>(Constants.ModId_WearMoreRings);
                 me.ItemExtensionsAPI = me.Helper.ModRegistry.GetApi<IItemExtensions>(Constants.ModId_ItemExtensions);
                 me.BetterGameMenuAPI = me.Helper.ModRegistry.GetApi<IBetterGameMenuApi>(Constants.ModId_BetterGameMenu);
+                me.ExtraAnimalConfigAPI = me.Helper.ModRegistry.GetApi<IExtraAnimalConfigApi>(Constants.ModId_ExtraAnimalConfig);
             }
             catch (Exception)
             {
@@ -285,7 +287,7 @@ namespace VanillaPlusProfessions
                         bird.update(Game1.currentGameTime, EmptyCritterRoom);
                     }
                 }
-            }            
+            }
         }
 
         private void OnWarped(object sender, WarpedEventArgs e)
@@ -312,7 +314,7 @@ namespace VanillaPlusProfessions
                                                      where tileobjpair.Value is not null && TalentUtility.IsBlandStone(tileobjpair.Value)
                                                      select tileobjpair.Key).ToList();
                         bool success = false;
-                        
+
                         Dictionary<Vector2, string> CoordinatesForMP = new();
                         for (int i = 0; i < validcoords.Count; i++)
                         {
@@ -487,7 +489,7 @@ namespace VanillaPlusProfessions
                             Game1.hudMessages.Add(new("Full inventory", HUDMessage.error_type));
                         }
                     }
-                    else if (Game1.player.currentLocation.Objects.TryGetValue(e.Cursor.Tile, out value2) && value2.ItemId == Constants.Id_BoxTrough && value2.lastInputItem.Value is null && Game1.player.ActiveObject?.ItemId == "178")
+                    else if (Game1.player.currentLocation.Objects.TryGetValue(e.Cursor.Tile, out value2) && value2.ItemId == Constants.Id_BoxTrough && value2.lastInputItem.Value is null && Game1.player.ActiveObject?.QualifiedItemId == (ExtraAnimalConfigAPI?.GetFeedOverride(Game1.currentLocation.ParentBuilding?.buildingType.Value) ?? "(O)178"))
                     {
                         value2.lastInputItem.Value = Game1.player.ActiveObject.getOne();
                         Game1.player.ActiveObject.ConsumeStack(1);


### PR DESCRIPTION
Tested with [Chicken Feed](https://www.nexusmods.com/stardewvalley/mods/26443), which changes every Coop to using Poultry Feed instead of Hay. Now if a building uses a different feed than hay, that feed will be used instead of hay to fill/autofill the box trough.

Requires the latest update of EAC for the new API function.