### PR TITLE
Prevent crashing from lightSource being null

### DIFF
--- a/C# Code/Craftables/CraftableHandler.cs
+++ b/C# Code/Craftables/CraftableHandler.cs
@@ -33,6 +33,7 @@ namespace VanillaPlusProfessions.Craftables
                 }
                 foreach (var item in loc.objects.Values)
                 {
+                    if (item.lightSource is null) continue;
                     if (item.ItemId == Constants.Id_GlowingCrystal && item.modData.ContainsKey(Constants.Key_GlowingCrystalColor))
                     {
                         string[] colorcodes = item.modData[Constants.Key_GlowingCrystalColor].Split(',');
@@ -162,7 +163,7 @@ namespace VanillaPlusProfessions.Craftables
             {
                 new(57, 2000, secondaryArm: false, flip: false, Farmer.canMoveNow, behaviorAtEndOfFrame: true)
             });
-            
+
             switch (effect)
             {
                 case "Sun":
@@ -199,7 +200,7 @@ namespace VanillaPlusProfessions.Craftables
                         delayBeforeAnimationStart = 2400,
                         drawAboveAlwaysFront = true
                     };
-                    
+
                     TotemSprite11.CopyAppearanceFromItemId(obj.QualifiedItemId);
                     Game1.Multiplayer.broadcastSprites(location, TotemSprite11);
 
@@ -208,7 +209,7 @@ namespace VanillaPlusProfessions.Craftables
                         Game1.Multiplayer.broadcastSprites(location, new TemporaryAnimatedSprite("TileSheets//Projectiles", new(48, 16, 16, 16), 9999f, 1, 0, who.Position + new Vector2(0f, -244f), flicker: false, flipped: false, 1.1f, 0.00085f, Color.White, 4f, 0f, 0f, 0f)
                         {
                             delayBeforeAnimationStart = 3000 + i * 150,
-                            motion= new Vector2((Game1.random.NextSingle() + Game1.random.NextSingle() + Game1.random.NextSingle()) * (Game1.random.NextBool() ? 1 : -1), -Game1.random.NextSingle()),
+                            motion = new Vector2((Game1.random.NextSingle() + Game1.random.NextSingle() + Game1.random.NextSingle()) * (Game1.random.NextBool() ? 1 : -1), -Game1.random.NextSingle()),
                         });
                     }
                     DelayedAction.playSoundAfterDelay("rainsound", 2000);
@@ -216,24 +217,40 @@ namespace VanillaPlusProfessions.Craftables
                 case "Snow":
                     TemporaryAnimatedSprite TotemSprite2 = new(0, 50f, 1, 65, Game1.player.Position + new Vector2(-16f, -96f), flicker: false, flipped: false, verticalFlipped: false, 0f)
                     {
-                        motion = new Vector2(0f, -7f), acceleration = new Vector2(0f, 0.15f), scaleChange = 0.005f,
-                        stopAcceleratingWhenVelocityIsZero = true, alpha = 1f, alphaFade = 0.00085f,
-                        shakeIntensity = 0.1f, initialPosition = Game1.player.Position + new Vector2(-16f, -96f),
-                        xPeriodic = true, xPeriodicLoopTime = 800f, xPeriodicRange = 5f, layerDepth = 1f,
+                        motion = new Vector2(0f, -7f),
+                        acceleration = new Vector2(0f, 0.15f),
+                        scaleChange = 0.005f,
+                        stopAcceleratingWhenVelocityIsZero = true,
+                        alpha = 1f,
+                        alphaFade = 0.00085f,
+                        shakeIntensity = 0.1f,
+                        initialPosition = Game1.player.Position + new Vector2(-16f, -96f),
+                        xPeriodic = true,
+                        xPeriodicLoopTime = 800f,
+                        xPeriodicRange = 5f,
+                        layerDepth = 1f,
                     };
                     TotemSprite2.CopyAppearanceFromItemId(obj.QualifiedItemId);
                     Game1.Multiplayer.broadcastSprites(location, TotemSprite2);
 
                     TemporaryAnimatedSprite TotemSprite22 = new(0, 9999f, 1, 9, Game1.player.Position + new Vector2(+16, -262f), flicker: false, flipped: false, verticalFlipped: false, 0f)
                     {
-                        alpha = 1f, shakeIntensity = 0.1f, alphaFade = 0.004f,
+                        alpha = 1f,
+                        shakeIntensity = 0.1f,
+                        alphaFade = 0.004f,
                         initialPosition = Game1.player.Position + new Vector2(-16f, -262f),
-                        layerDepth = 1f, xPeriodic = true, xPeriodicLoopTime = 800f, xPeriodicRange = 5f,
-                        scale = 1.2f, scaleChange = 0.0005f, delayBeforeAnimationStart = 2400, drawAboveAlwaysFront = true
+                        layerDepth = 1f,
+                        xPeriodic = true,
+                        xPeriodicLoopTime = 800f,
+                        xPeriodicRange = 5f,
+                        scale = 1.2f,
+                        scaleChange = 0.0005f,
+                        delayBeforeAnimationStart = 2400,
+                        drawAboveAlwaysFront = true
                     };
                     TotemSprite22.CopyAppearanceFromItemId(obj.QualifiedItemId);
                     Game1.Multiplayer.broadcastSprites(location, TotemSprite22);
-                    
+
                     for (int i = 0; i < 10; i++)
                     {
                         Game1.Multiplayer.broadcastSprites(location, new TemporaryAnimatedSprite(ContentEditor.ContentPaths["Animations"], new(16 + Game1.random.Choose(0, 16, 32, 48), 32 + Game1.random.Choose(0, 16), 16, 16), 9999f, 1, 0, who.Position + new Vector2(0f, -244f), flicker: false, flipped: false, 1.1f, 0.00085f, Color.White, 4f, 0f, 0f, (float)(System.Math.PI / 180))
@@ -248,10 +265,17 @@ namespace VanillaPlusProfessions.Craftables
                 case "Wild":
                     TemporaryAnimatedSprite TotemSprite3 = new(0, 50f, 1, 999, Game1.player.Position + new Vector2(0f, -96f), flicker: false, flipped: false, verticalFlipped: false, 0f)
                     {
-                        motion = new Vector2(0f, -4f), acceleration = new Vector2(0f, 0.05f), scaleChange = 0.005f,
-                        alpha = 1f, alphaFade = 0.0075f, shakeIntensity = 1f,
+                        motion = new Vector2(0f, -4f),
+                        acceleration = new Vector2(0f, 0.05f),
+                        scaleChange = 0.005f,
+                        alpha = 1f,
+                        alphaFade = 0.0075f,
+                        shakeIntensity = 1f,
                         initialPosition = Game1.player.Position + new Vector2(0f, -96f),
-                        xPeriodic = true, xPeriodicLoopTime = 1000f, xPeriodicRange = 4f, layerDepth = 1f,
+                        xPeriodic = true,
+                        xPeriodicLoopTime = 1000f,
+                        xPeriodicRange = 4f,
+                        layerDepth = 1f,
                     };
                     TotemSprite3.CopyAppearanceFromItemId(obj.QualifiedItemId);
                     Game1.Multiplayer.broadcastSprites(location, TotemSprite3);

--- a/C# Code/Craftables/MachineryEventHandler.cs
+++ b/C# Code/Craftables/MachineryEventHandler.cs
@@ -111,7 +111,7 @@ namespace VanillaPlusProfessions.Craftables
                 {
                     if (obj.Location is not null && Game1.isTimeToTurnOffLighting(obj.Location))
                     {
-                        if (obj.ItemId == Constants.Id_GlowingCrystal && obj.modData.ContainsKey(Constants.Key_GlowingCrystalColor))
+                        if (obj.ItemId == Constants.Id_GlowingCrystal && obj.modData.ContainsKey(Constants.Key_GlowingCrystalColor) && obj.lightSource is not null)
                         {
                             string[] colorcodes = obj.modData[Constants.Key_GlowingCrystalColor].Split(',');
                             obj.lightSource.color.Value = new Color(byte.Parse(colorcodes[0]), byte.Parse(colorcodes[1]), byte.Parse(colorcodes[2]), byte.Parse(colorcodes[3]));
@@ -128,7 +128,7 @@ namespace VanillaPlusProfessions.Craftables
             {
                 var loc = Game1.getLocationFromName(item.Key);
 
-                foreach (var item2 in item.Value) 
+                foreach (var item2 in item.Value)
                 {
                     Chest inputChest = new();
                     Chest batteryChest = new();
@@ -417,12 +417,12 @@ namespace VanillaPlusProfessions.Craftables
             if (building?.buildingType.Value == Constants.Id_MinecartRepository)
             {
                 Chest defaultChest = (MineTent ?? building).GetBuildingChest("Default_Chest");
-                
+
                 foreach (var objs in Game1.player.team.GetOrCreateGlobalInventory(Constants.GlobalInventoryId_Minecarts))
                 {
                     if (objs is null)
                         continue;
-                    
+
                     if (Utility.canItemBeAddedToThisInventoryList(objs.getOne(), defaultChest.Items, defaultChest.GetActualCapacity()) && objs is not Tool)
                     {
                         foreach (var item in defaultChest.Items)
@@ -437,7 +437,7 @@ namespace VanillaPlusProfessions.Craftables
                             defaultChest.Items.Add(objs);
                             Game1.player.team.GetOrCreateGlobalInventory(Constants.GlobalInventoryId_Minecarts).RemoveButKeepEmptySlot(objs);
                         }
-                        
+
                         if (objs.Stack == 0)
                         {
                             Game1.player.team.GetOrCreateGlobalInventory(Constants.GlobalInventoryId_Minecarts).RemoveButKeepEmptySlot(objs);

--- a/C# Code/Craftables/MachineryPatcher.cs
+++ b/C# Code/Craftables/MachineryPatcher.cs
@@ -20,11 +20,11 @@ namespace VanillaPlusProfessions.Craftables
                 transpiler: new(typeof(MachineryPatcher), nameof(draw_Critter_Transpiler))
             );
             CoreUtility.PatchMethod("MachineryPatcher", "StardewValley.Object.draw_3",
-                original: AccessTools.Method(typeof(StardewValley.Object), nameof(StardewValley.Object.draw), new System.Type[] { typeof(SpriteBatch), typeof(int), typeof(int), typeof(float), typeof(float)}),
+                original: AccessTools.Method(typeof(StardewValley.Object), nameof(StardewValley.Object.draw), new System.Type[] { typeof(SpriteBatch), typeof(int), typeof(int), typeof(float), typeof(float) }),
                 transpiler: new(typeof(MachineryPatcher), nameof(draw_SObject_Transpiler_3))
             );
             CoreUtility.PatchMethod("MachineryPatcher", "StardewValley.Object.draw_4",
-               original: AccessTools.Method(typeof(StardewValley.Object), nameof(StardewValley.Object.draw), new System.Type[] { typeof(SpriteBatch), typeof(int), typeof(int), typeof(float)}),
+               original: AccessTools.Method(typeof(StardewValley.Object), nameof(StardewValley.Object.draw), new System.Type[] { typeof(SpriteBatch), typeof(int), typeof(int), typeof(float) }),
                transpiler: new(typeof(MachineryPatcher), nameof(draw_SObject_Transpiler_4))
             );
         }
@@ -58,9 +58,7 @@ namespace VanillaPlusProfessions.Craftables
             {
                 int count = 5;
                 var method = AccessTools.PropertyGetter(typeof(Color), "White");
-                var prop = AccessTools.PropertyGetter(typeof(Object), "lightSource");
-                var field = AccessTools.Field(typeof(LightSource), "color");
-                var prop2 = AccessTools.PropertyGetter(typeof(Netcode.NetColor), "Value");
+                var getColorMethod = AccessTools.Method(typeof(MachineryPatcher), nameof(MaybeGetLightSourceColor));
                 foreach (var item in insns)
                 {
                     if (item.Is(OpCodes.Call, method))
@@ -69,9 +67,7 @@ namespace VanillaPlusProfessions.Craftables
                         if (count == 0)
                         {
                             list.Add(new(OpCodes.Ldarg_0));
-                            list.Add(new(OpCodes.Call, prop));
-                            list.Add(new(OpCodes.Ldfld, field));
-                            list.Add(new(OpCodes.Call, prop2));
+                            list.Add(new(OpCodes.Call, getColorMethod));
                             continue;
                         }
                     }
@@ -91,9 +87,7 @@ namespace VanillaPlusProfessions.Craftables
             {
                 int count = 3;
                 var method = AccessTools.PropertyGetter(typeof(Color), "White");
-                var prop = AccessTools.PropertyGetter(typeof(Object), "lightSource");
-                var field = AccessTools.Field(typeof(LightSource), "color");
-                var prop2 = AccessTools.PropertyGetter(typeof(Netcode.NetColor), "Value");
+                var getColorMethod = AccessTools.Method(typeof(MachineryPatcher), nameof(MaybeGetLightSourceColor));
                 foreach (var item in insns)
                 {
                     if (item.Is(OpCodes.Call, method))
@@ -102,9 +96,7 @@ namespace VanillaPlusProfessions.Craftables
                         if (count == 0)
                         {
                             list.Add(new(OpCodes.Ldarg_0));
-                            list.Add(new(OpCodes.Call, prop));
-                            list.Add(new(OpCodes.Ldfld, field));
-                            list.Add(new(OpCodes.Call, prop2));
+                            list.Add(new(OpCodes.Call, getColorMethod));
                             continue;
                         }
                     }
@@ -116,6 +108,11 @@ namespace VanillaPlusProfessions.Craftables
                 CoreUtility.PrintError(e, "MachineryPatcher", "Critter.draw", "transpiler");
             }
             return list;
+        }
+
+        static Color MaybeGetLightSourceColor(StardewValley.Object obj)
+        {
+            return obj.lightSource?.color.Value ?? Color.White;
         }
     }
 }


### PR DESCRIPTION
Someone reported a crash in the object draw code, and I have good reason to believe it's because `lightSource` is null, causing the transpiled draw code in `Object` to crash: https://smapi.io/log/a0d2a64c0e724a0890382de53f8c90a0

I don't know why it's null (likely interference from another mod?), but it helps to be resilient against this possibility regardless. The transpiler code is the most important part; though I inserted null checks in a bunch of other places as well just in case.

(also my editor autoformatted a bunch of lines; sorry :P )